### PR TITLE
Fixes #149: When the user specifies a NULL output-function pointer, g…

### DIFF
--- a/src/printf/printf.c
+++ b/src/printf/printf.c
@@ -1418,6 +1418,7 @@ int vsprintf_(char* s, const char* format, va_list arg)
 
 int vfctprintf(void (*out)(char c, void* extra_arg), void* extra_arg, const char* format, va_list arg)
 {
+  if (out == NULL) { return 0; }
   output_gadget_t gadget = function_gadget(out, extra_arg);
   return vsnprintf_impl(&gadget, format, arg);
 }


### PR DESCRIPTION
…ive up immediately and avoid NULL-dereferencing situations (which GCC's static analyzer complains about)